### PR TITLE
Updating Jenkins baseline supported version to 2.528.3 (#272)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.1</version>
+    <version>5.17</version>
   </parent>
 
   <artifactId>p4</artifactId>
@@ -16,7 +16,7 @@
   <url>https://github.com/jenkinsci/p4-plugin</url>
 
   <properties>
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
@@ -59,27 +59,11 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4924.v6b_eb_a_79a_d9d0</version>
+        <version>6607.v3ed3d8ddfed8</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.18.6</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-       <version>2.18.6</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.18.6</version>
-      </dependency>
-      <dependency>
-
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>1.84</version>
@@ -100,19 +84,29 @@
         <version>1.84</version>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>credentials-binding</artifactId>
-        <version>687.689.v1a_f775332fc9</version>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-cps</artifactId>
+        <version>4331.4333.v50a_b_076c5199</version>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-step-api</artifactId>
-        <version>704.ve4f0967e98fa_</version>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>script-security</artifactId>
+        <version>1402.1405.vc96e74964250</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials-binding</artifactId>
+        <version>725.ve52b_2328a_fde</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>jackson2-api</artifactId>
+        <version>2.22.0-439.vb_b_43658d6176</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
+        <version>3.20.0</version>
       </dependency>
       <dependency>
         <groupId>org.mozilla</groupId>
@@ -154,7 +148,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>3.20.0</version>
     </dependency>
 
     <dependency>
@@ -191,7 +185,6 @@
     </dependency>
 
     <!-- Jenkins dependencies -->
-
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
@@ -219,7 +212,6 @@
     </dependency>
 
     <!-- Workflow dependencies (aggregator) -->
-
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
@@ -246,7 +238,6 @@
     </dependency>
 
     <!-- Optional dependencies -->
-
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>multiple-scms</artifactId>
@@ -261,7 +252,6 @@
     </dependency>
 
     <!-- Test scope dependencies -->
-
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
@@ -300,9 +290,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.27.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20250517</version>
+      <version>20251224</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/p4/credentials/P4CredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/p4/credentials/P4CredentialsImpl.java
@@ -4,7 +4,6 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Item;
 import hudson.model.Queue;
 import hudson.model.queue.Tasks;
@@ -35,7 +34,7 @@ public class P4CredentialsImpl {
 				acl, domain);
 
 		if (credentials.isEmpty()) {
-			list.add("Select credential...", null);
+			list.add("Select credential...", "");
 		}
 		for (P4BaseCredentials c : credentials) {
 			StringBuffer sb = new StringBuffer();
@@ -50,7 +49,6 @@ public class P4CredentialsImpl {
 		return list;
 	}
 
-	@SuppressFBWarnings(value="NP_NULL_PARAM_DEREF", justification="pending https://github.com/jenkinsci/credentials-plugin/pull/68")
 	static public ListBoxModel doFillCredentialItems(Item project, String credentialsId) {
 
 		if(project == null && !Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) ||

--- a/src/test/java/org/jenkinsci/plugins/p4/client/GraphWorkFlowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/p4/client/GraphWorkFlowTest.java
@@ -6,6 +6,7 @@ import org.jenkinsci.plugins.p4.workflow.source.AbstractSource;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import hudson.FilePath;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -43,6 +46,20 @@ class GraphWorkFlowTest extends DefaultEnvironment {
     @BeforeEach
     void beforeEach() throws Exception {
 		createCredentials("jenkins", "Password", p4d.getRshPort(), CREDENTIAL);
+	}
+
+	@AfterEach
+	void afterEach() throws Exception {
+		// Perforce syncs files read-only. On Windows a leftover read-only tree
+		// breaks the next build's `mvn clean` (it cannot delete read-only files).
+		// Remove each job's workspace so the synced files do not survive the test;
+		// FilePath.deleteRecursive() clears the read-only attribute before deleting.
+		for (WorkflowJob job : jenkins.jenkins.getAllItems(WorkflowJob.class)) {
+			FilePath workspace = jenkins.jenkins.getWorkspaceFor(job);
+			if (workspace != null) {
+				workspace.deleteRecursive();
+			}
+		}
 	}
 
 	// Test for syncing a graph source using script with source specified


### PR DESCRIPTION
* Updating Jenkins baseline supported version to 2.516.3

Bump the plugin parent POM 5.1 -> 5.17 so the test tooling matches the 2.516 baseline. Parent 5.1 pinned maven-hpi-plugin 3.58 + jenkins-test-harness 2307, which do not correctly assemble the Jetty 12 EE9 test webapp: the Stapler filter chain is never mapped, so JenkinsRule WebClient.getPage(...) returns a bare Jetty 404 (SERVLET: default) for every URL except the context root. That broke the web-facing tests (FreeStyleTest, ReviewImplTest, PerforceSCMSourceTest and the generated InjectedTest jelly suite). Parent 5.17 brings hpi 3.65 + jenkins-test-harness 2447 (JENKINS-75572), which supports Jetty 12 EE9 and restores routing. No plugin code changes required.

* Bump Jenkins baseline to 2.528.3 and pin dependency security fixes

- baseline 2.516 -> 2.528, BOM 5601 -> 6607
- pin script-security, credentials-binding and jackson2-api to fixed versions
- commons-lang3 3.19.0 -> 3.20.0, json 20250517 -> 20251224
- GraphWorkFlowTest: delete each job workspace in @AfterEach so read-only p4-synced files do not survive the test and break the next mvn clean